### PR TITLE
More improved performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rivo/uniseg
+module github.com/Code-Hex/uniseg
 
-go 1.12
+go 1.13

--- a/grapheme.go
+++ b/grapheme.go
@@ -118,7 +118,11 @@ type Graphemes struct {
 
 // NewGraphemes returns a new grapheme cluster iterator.
 func NewGraphemes(s string) *Graphemes {
-	g := &Graphemes{}
+	ln := len(s)
+	g := &Graphemes{
+		codePoints: make([]rune, 0, ln),
+		indices:    make([]int, 0, ln+1),
+	}
 	for index, codePoint := range s {
 		g.codePoints = append(g.codePoints, codePoint)
 		g.indices = append(g.indices, index)


### PR DESCRIPTION
This PR will be improving performance when called `GraphemeClusterCount` function.

**benchmark code.**
```go
func BenchmarkCountBefore(b *testing.B) {
	for i := 0; i < b.N; i++ {
		for _, bcase := range testCases {
			g := beforeNewGraphemes(bcase.original)
			var n int
			for g.Next() {
				n++
			}
		}
	}
}

func beforeNewGraphemes(s string) *Graphemes {
	g := &Graphemes{}
	for index, codePoint := range s {
		g.codePoints = append(g.codePoints, codePoint)
		g.indices = append(g.indices, index)
	}
	g.indices = append(g.indices, len(s))
	g.Next()
	return g
}

func BenchmarkCountAfter(b *testing.B) {
	for i := 0; i < b.N; i++ {
		for _, bcase := range testCases {
			g := NewGraphemes(bcase.original)
			var n int
			for g.Next() {
				n++
			}
		}
	}
}
```

**Result**

```
go test -benchmem -run="^$" github.com/rivo/uniseg -bench .
goos: darwin
goarch: amd64
pkg: github.com/rivo/uniseg
BenchmarkCountBefore-8              5000            247797 ns/op           96392 B/op       3458 allocs/op
BenchmarkCountAfter-8              10000            199063 ns/op          105544 B/op       1865 allocs/op
```