### PR TITLE
Faster split as runes, reduced memory usage, allocs

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,68 @@
+package uniseg
+
+import (
+	"testing"
+)
+
+func BenchmarkCountOriginal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, bcase := range testCases {
+			g := originalNewGraphemes(bcase.original)
+			var n int
+			for g.Next() {
+				n++
+			}
+		}
+	}
+}
+
+func originalNewGraphemes(s string) *Graphemes {
+	g := &Graphemes{}
+	for index, codePoint := range s {
+		g.codePoints = append(g.codePoints, codePoint)
+		g.indices = append(g.indices, index)
+	}
+	g.indices = append(g.indices, len(s))
+	g.Next()
+	return g
+}
+
+func BenchmarkCountCodeHex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, bcase := range testCases {
+			g := codeHexNewGraphemes(bcase.original)
+			var n int
+			for g.Next() {
+				n++
+			}
+		}
+	}
+}
+
+// https://github.com/rivo/uniseg/pull/5
+func codeHexNewGraphemes(s string) *Graphemes {
+	ln := len(s)
+	g := &Graphemes{
+		codePoints: make([]rune, 0, ln),
+		indices:    make([]int, 0, ln+1),
+	}
+	for index, codePoint := range s {
+		g.codePoints = append(g.codePoints, codePoint)
+		g.indices = append(g.indices, index)
+	}
+	g.indices = append(g.indices, len(s))
+	g.Next()
+	return g
+}
+
+func BenchmarkCountDolmen(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, bcase := range testCases {
+			g := NewGraphemes(bcase.original)
+			var n int
+			for g.Next() {
+				n++
+			}
+		}
+	}
+}

--- a/grapheme.go
+++ b/grapheme.go
@@ -1,5 +1,7 @@
 package uniseg
 
+import "unicode/utf8"
+
 // The states of the grapheme cluster parser.
 const (
 	grAny = iota
@@ -118,12 +120,20 @@ type Graphemes struct {
 
 // NewGraphemes returns a new grapheme cluster iterator.
 func NewGraphemes(s string) *Graphemes {
-	g := &Graphemes{}
-	for index, codePoint := range s {
-		g.codePoints = append(g.codePoints, codePoint)
-		g.indices = append(g.indices, index)
+	l := utf8.RuneCountInString(s)
+	codePoints := make([]rune, l)
+	indices := make([]int, l+1)
+	i := 0
+	for pos, r := range s {
+		codePoints[i] = r
+		indices[i] = pos
+		i++
 	}
-	g.indices = append(g.indices, len(s))
+	indices[l] = len(s)
+	g := &Graphemes{
+		codePoints: codePoints,
+		indices:    indices,
+	}
 	g.Next() // Parse ahead.
 	return g
 }


### PR DESCRIPTION
This is an alternative to #5 (Cc: @Code-Hex).
A bit slower than #5, but much less memory used. Still significantly faster than the original `NewGraphemes`.

The second commit is the benchmark. Just cherry-pick the first commit if you don't want the benchmark.

```
$ go test -benchmem -bench B
goos: darwin
goarch: amd64
pkg: github.com/rivo/uniseg
BenchmarkCountOriginal-4   	    2991	    387297 ns/op	   96392 B/op	    3458 allocs/op
BenchmarkCountCodeHex-4    	    4665	    274718 ns/op	  105544 B/op	    1865 allocs/op
BenchmarkCountDolmen-4     	    4227	    291797 ns/op	   77776 B/op	    1865 allocs/op
```


