### PR TITLE
introduce GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        go:
+          - "1.16"
+          - "1.15"
+          - "1.14"
+          - "1.13"
+          - "1.12"
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: test
+        run: |
+          go test ./...


### PR DESCRIPTION
It looks that there is not any Continuous Integration.
So, I propose to use GitHub Actions.
It is provided by GitHub and it is very easy to introduce it.

Any workflow doesn't run when this pull request is created,
because merging to the default branch is required to run the workflows at first time.
So if you want to check the result, see the logs on my forked repository: https://github.com/shogo82148/uniseg/actions/runs/833056219
