### PR TITLE
migrate godoc.org to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unicode Text Segmentation for Go
 
-[![Godoc Reference](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/rivo/uniseg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/rivo/uniseg.svg)](https://pkg.go.dev/github.com/rivo/uniseg)
 [![Go Report](https://img.shields.io/badge/go%20report-A%2B-brightgreen.svg)](https://goreportcard.com/report/github.com/rivo/uniseg)
 
 This Go package implements Unicode Text Segmentation according to [Unicode Standard Annex #29](http://unicode.org/reports/tr29/) (Unicode version 12.0.0).
@@ -47,7 +47,7 @@ func main() {
 
 ## Documentation
 
-Refer to https://godoc.org/github.com/rivo/uniseg for the package's documentation.
+Refer to https://pkg.go.dev/github.com/rivo/uniseg for the package's documentation.
 
 ## Dependencies
 


### PR DESCRIPTION
The links for godoc.org still work, while linking to pkg.go.dev directly has better experience.
The badge is generated by https://pkg.go.dev/badge/

ref. Redirecting godoc.org requests to pkg.go.dev
https://blog.golang.org/godoc.org-redirect