### PR TITLE
Add ResetString

### DIFF
--- a/grapheme.go
+++ b/grapheme.go
@@ -120,22 +120,9 @@ type Graphemes struct {
 
 // NewGraphemes returns a new grapheme cluster iterator.
 func NewGraphemes(s string) *Graphemes {
-	l := utf8.RuneCountInString(s)
-	codePoints := make([]rune, l)
-	indices := make([]int, l+1)
-	i := 0
-	for pos, r := range s {
-		codePoints[i] = r
-		indices[i] = pos
-		i++
-	}
-	indices[l] = len(s)
-	g := &Graphemes{
-		codePoints: codePoints,
-		indices:    indices,
-	}
-	g.Next() // Parse ahead.
-	return g
+	var g Graphemes
+	g.ResetString(s)
+	return &g
 }
 
 // Next advances the iterator by one grapheme cluster and returns false if no

--- a/grapheme.go
+++ b/grapheme.go
@@ -121,7 +121,7 @@ type Graphemes struct {
 // NewGraphemes returns a new grapheme cluster iterator.
 func NewGraphemes(s string) *Graphemes {
 	var g Graphemes
-	g.ResetString(s)
+	g.ResetToString(s)
 	return &g
 }
 
@@ -243,9 +243,9 @@ func (g *Graphemes) Reset() {
 	g.Next() // Parse ahead again.
 }
 
-// ResetString resets and parses a new string.
+// ResetToString resets and parses a new string.
 // This will reuse allocations in g, but act as NewGraphemes.
-func (g *Graphemes) ResetString(s string) {
+func (g *Graphemes) ResetToString(s string) {
 	l := utf8.RuneCountInString(s)
 	codePoints := g.codePoints
 	if cap(codePoints) < l {

--- a/grapheme.go
+++ b/grapheme.go
@@ -256,6 +256,34 @@ func (g *Graphemes) Reset() {
 	g.Next() // Parse ahead again.
 }
 
+// ResetString resets and parses a new string.
+// This will reuse allocations in g, but act as NewGraphemes.
+func (g *Graphemes) ResetString(s string) {
+	l := utf8.RuneCountInString(s)
+	codePoints := g.codePoints
+	if cap(codePoints) < l {
+		codePoints = make([]rune, l)
+	}
+	codePoints = codePoints[:l]
+	indices := g.indices
+	if cap(codePoints) <= l {
+		indices = make([]int, l+1)
+	}
+	indices = indices[:l+1]
+
+	i := 0
+	for pos, r := range s {
+		codePoints[i] = r
+		indices[i] = pos
+		i++
+	}
+	indices[l] = len(s)
+	g.indices = indices
+	g.codePoints = codePoints
+	g.start, g.end, g.pos, g.state = 0, 0, 0, grAny
+	g.Next() // Parse ahead.
+}
+
 // GraphemeClusterCount returns the number of user-perceived characters
 // (grapheme clusters) for the given string. To calculate this number, it
 // iterates through the string using the Graphemes iterator.

--- a/grapheme_test.go
+++ b/grapheme_test.go
@@ -704,7 +704,7 @@ func TestSimple(t *testing.T) {
 func TestSimpleResetString(t *testing.T) {
 	gr := NewGraphemes("")
 	for testNum, testCase := range testCases {
-		gr.ResetString(testCase.original)
+		gr.ResetToString(testCase.original)
 		var index int
 	GraphemeLoop:
 		for index = 0; gr.Next(); index++ {
@@ -871,7 +871,7 @@ func BenchmarkCountResetString(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, bcase := range testCases {
 			var n int
-			g.ResetString(bcase.original)
+			g.ResetToString(bcase.original)
 			for g.Next() {
 				n++
 			}

--- a/grapheme_test.go
+++ b/grapheme_test.go
@@ -704,12 +704,6 @@ func TestSimple(t *testing.T) {
 func TestSimpleResetString(t *testing.T) {
 	gr := NewGraphemes("")
 	for testNum, testCase := range testCases {
-		/*t.Logf(`Test case %d "%s": Expecting %x, getting %x, code points %x"`,
-		testNum,
-		strings.TrimSpace(testCase.original),
-		testCase.expected,
-		decomposed(testCase.original),
-		[]rune(testCase.original))*/
 		gr.ResetString(testCase.original)
 		var index int
 	GraphemeLoop:
@@ -856,7 +850,7 @@ func TestCount(t *testing.T) {
 	}
 }
 
-func BenchmarkCountDolmen(b *testing.B) {
+func BenchmarkCount(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -870,7 +864,7 @@ func BenchmarkCountDolmen(b *testing.B) {
 	}
 }
 
-func BenchmarkCountDolmenResetString(b *testing.B) {
+func BenchmarkCountResetString(b *testing.B) {
 	g := NewGraphemes("")
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
Add ResetString that allows to reuse the Grapheme without allocating internals.

Copied a simple benchmark to verify it:

```
cpu: AMD Ryzen 9 3950X 16-Core Processor
BenchmarkCountDolmen-32               	    7058	    164430 ns/op	   75297 B/op	    1865 allocs/op
BenchmarkCountDolmenResetString-32    	   12128	     98766 ns/op	      96 B/op	       1 allocs/op
PASS
```