### PR TITLE
Fix breaking of the next emoji after the control character

### DIFF
--- a/grapheme.go
+++ b/grapheme.go
@@ -33,8 +33,8 @@ const (
 //   2. Find specific state + any property.
 //   3. Find any state + specific property.
 //   4. If only (2) or (3) (but not both) was found, stop.
-//   5. If both (2) and (3) were found, use state and breaking instruction from
-//      the transition with the lower rule number, prefer (3) if rule numbers
+//   5. If both (2) and (3) were found, use state from (3) and breaking instruction
+//      from the transition with the lower rule number, prefer (3) if rule numbers
 //      are equal. Stop.
 //   6. Assume grAny and grBoundary.
 var grTransitions = map[[2]int][3]int{
@@ -176,7 +176,6 @@ func (g *Graphemes) Next() bool {
 				g.state = transAnyState[0]
 				boundary = transAnyState[1] == grBoundary
 				if transAnyProp[2] < transAnyState[2] {
-					g.state = transAnyProp[0]
 					boundary = transAnyProp[1] == grBoundary
 				}
 			} else if okAnyProp {

--- a/grapheme_test.go
+++ b/grapheme_test.go
@@ -31,6 +31,8 @@ var testCases = []testCase{
 	{original: "🙂🙂", expected: [][]rune{{0x1f642}, {0x1f642}}},
 	{original: "🇩🇪", expected: [][]rune{{0x1f1e9, 0x1f1ea}}},
 	{original: "🏳️‍🌈", expected: [][]rune{{0x1f3f3, 0xfe0f, 0x200d, 0x1f308}}},
+	{original: "\t🏳️‍🌈", expected: [][]rune{{0x9}, {0x1f3f3, 0xfe0f, 0x200d, 0x1f308}}},
+	{original: "\t🏳️‍🌈\t", expected: [][]rune{{0x9}, {0x1f3f3, 0xfe0f, 0x200d, 0x1f308}, {0x9}}},
 }
 
 // decomposed returns a grapheme cluster decomposition.


### PR DESCRIPTION
When a control character is followed by a emoji, such as `\t🏳️‍🌈`, the state seems to be broken at the transition to the next, causing the emoji grapheme to split.

https://play.golang.org/p/jUX-VcrwFnm

This is due to the loss of state of the emoji when applying the rule on transition from the control character to the next character.

In this PR, only the boundary condition uses the lower rule number, and the state is not overwritten.