### PR TITLE
optimize data structures for 5.5x speedup

### DIFF
--- a/grapheme_test.go
+++ b/grapheme_test.go
@@ -343,6 +343,17 @@ func BenchmarkGraphemesClass(b *testing.B) {
 	}
 }
 
+func BenchmarkGraphemesNext(b *testing.B) {
+	g := NewGraphemes(benchmarkStr)
+	orig := *g
+	for i := 0; i < b.N; i++ {
+		for g.Next() {
+			resultRunes = g.Runes()
+		}
+		*g = orig
+	}
+}
+
 // Benchmark the use of the Graphemes function for byte slices.
 func BenchmarkGraphemesFunctionBytes(b *testing.B) {
 	str := []byte(benchmarkStr)

--- a/graphemeproperties.go
+++ b/graphemeproperties.go
@@ -2,13 +2,19 @@
 
 package uniseg
 
+type codePoint struct {
+	lo, hi   rune
+	property uint8
+}
+
 // graphemeCodePoints are taken from
 // https://www.unicode.org/Public/14.0.0/ucd/auxiliary/GraphemeBreakProperty.txt,
 // and
 // https://unicode.org/Public/14.0.0/ucd/emoji/emoji-data.txt,
 // ("Extended_Pictographic" only) on March 11, 2019. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
-var graphemeCodePoints = [][3]int{{0x0000, 0x0009, prControl}, // Cc  [10] <control-0000>..<control-0009>
+var graphemeCodePoints = []codePoint{
+	{0x0000, 0x0009, prControl},                // Cc  [10] <control-0000>..<control-0009>
 	{0x000A, 0x000A, prLF},                     // Cc       <control-000A>
 	{0x000B, 0x000C, prControl},                // Cc   [2] <control-000B>..<control-000C>
 	{0x000D, 0x000D, prCR},                     // Cc       <control-000D>
@@ -1887,3 +1893,4 @@ var graphemeCodePoints = [][3]int{{0x0000, 0x0009, prControl}, // Cc  [10] <cont
 	{0xE0100, 0xE01EF, prExtend},               // Mn [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
 	{0xE01F0, 0xE0FFF, prControl},              // Cn [3600] <reserved-E01F0>..<reserved-E0FFF>
 }
+

--- a/properties.go
+++ b/properties.go
@@ -18,26 +18,53 @@ const (
 	prLVT
 	prZWJ
 	prExtendedPictographic
+
+	_prLast
 )
+
+// ASCII and Extended ASCII properties
+var asciiGraphemeProperties = [256]uint8{
+	'\x00': prControl, '\x01': prControl, '\x02': prControl, '\x03': prControl,
+	'\x04': prControl, '\x05': prControl, '\x06': prControl, '\x07': prControl,
+	'\x08': prControl, '\x09': prControl, '\x0a': prLF, '\x0b': prControl,
+	'\x0c': prControl, '\x0d': prCR, '\x0e': prControl, '\x0f': prControl,
+	'\x10': prControl, '\x11': prControl, '\x12': prControl, '\x13': prControl,
+	'\x14': prControl, '\x15': prControl, '\x16': prControl, '\x17': prControl,
+	'\x18': prControl, '\x19': prControl, '\x1a': prControl, '\x1b': prControl,
+	'\x1c': prControl, '\x1d': prControl, '\x1e': prControl, '\x1f': prControl,
+	'\x7f': prControl, '\x80': prControl, '\x81': prControl, '\x82': prControl,
+	'\x83': prControl, '\x84': prControl, '\x85': prControl, '\x86': prControl,
+	'\x87': prControl, '\x88': prControl, '\x89': prControl, '\x8a': prControl,
+	'\x8b': prControl, '\x8c': prControl, '\x8d': prControl, '\x8e': prControl,
+	'\x8f': prControl, '\x90': prControl, '\x91': prControl, '\x92': prControl,
+	'\x93': prControl, '\x94': prControl, '\x95': prControl, '\x96': prControl,
+	'\x97': prControl, '\x98': prControl, '\x99': prControl, '\x9a': prControl,
+	'\x9b': prControl, '\x9c': prControl, '\x9d': prControl, '\x9e': prControl,
+	'\x9f': prControl, '\xa9': prExtendedPictographic, '\xad': prControl,
+	'\xae': prExtendedPictographic,
+}
 
 // property returns the Unicode property value (see constants above) of the
 // given code point.
 func property(r rune) int {
+	// ASCII and Extended ASCII fast path
+	if r < rune(len(asciiGraphemeProperties)) {
+		return int(asciiGraphemeProperties[r])
+	}
+
 	// Run a binary search.
 	from := 0
 	to := len(graphemeCodePoints)
 	for to > from {
-		middle := (from + to) / 2
-		cpRange := graphemeCodePoints[middle]
-		if int(r) < cpRange[0] {
+		middle := int(uint(from+to) >> 1)
+		p := graphemeCodePoints[middle]
+		if r < p.lo {
 			to = middle
-			continue
-		}
-		if int(r) > cpRange[1] {
+		} else if r > p.hi {
 			from = middle + 1
-			continue
+		} else {
+			return int(p.property)
 		}
-		return cpRange[2]
 	}
 	return prAny
 }

--- a/properties_test.go
+++ b/properties_test.go
@@ -1,0 +1,129 @@
+package uniseg
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// Reference implementation using brute-force-search
+func propertyReference(r rune) (property int, cp *codePoint) {
+	for _, p := range graphemeCodePoints {
+		if p.lo <= r && r <= p.hi {
+			return int(p.property), &p
+		}
+	}
+	return prAny, nil
+}
+
+var _propertyStrings = [...]string{
+	"prAny",
+	"prPrepend",
+	"prCR",
+	"prLF",
+	"prControl",
+	"prExtend",
+	"prRegionalIndicator",
+	"prSpacingMark",
+	"prL",
+	"prV",
+	"prT",
+	"prLV",
+	"prLVT",
+	"prZWJ",
+	"prExtendedPictographic",
+}
+
+func propertyToString(p uint8) string {
+	if p < uint8(len(_propertyStrings)) {
+		return _propertyStrings[p]
+	}
+	return fmt.Sprintf("pr(%d)", p)
+}
+
+func formatCodePoint(p *codePoint) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{%X, %X, %s}", p.lo, p.hi, propertyToString(p.property))
+}
+
+func testPropertyRange(t *testing.T, wg *sync.WaitGroup, failures *int32, start, end rune) {
+	defer func() {
+		if wg != nil {
+			wg.Done()
+		}
+	}()
+	for r := start; r < end; r++ {
+		want, cp := propertyReference(r)
+		got := property(r)
+		if got != want {
+			t.Errorf("property(%q) = %s; want: %s\n\t%s", r,
+				propertyToString(uint8(got)), propertyToString(uint8(want)), formatCodePoint(cp))
+			if failures != nil && atomic.AddInt32(failures, 1) > 10 {
+				return
+			}
+		}
+	}
+}
+
+func TestProperty_ASCII(t *testing.T) {
+	// Test ASCII and extended ASCII
+	testPropertyRange(t, nil, nil, 0, 256)
+}
+
+func clampInt64(i, max int64) int64 {
+	if i <= max {
+		return i
+	}
+	return max
+}
+
+// Exhaustive test of all code points between 0 and the highest grapheme + 8.
+func TestProperty(t *testing.T) {
+	const MaxRune = 1<<32 - 1
+	if testing.Short() {
+		t.Skip("skipping: short test")
+	}
+
+	// Use int64 to prevent overflow on 32-bit systems
+	end := int64(graphemeCodePoints[len(graphemeCodePoints)-1].hi) + 8
+	if MaxRune-end > 8 {
+		end += 8 // +8 to make sure it works outside of the range
+	}
+	delta := end/int64(runtime.NumCPU()) + 1
+
+	var wg sync.WaitGroup
+	var failures int32
+	for i := int64(0); i <= end; i += delta {
+		wg.Add(1)
+		go testPropertyRange(t, &wg, &failures, rune(i), rune(clampInt64(i+delta, end)))
+	}
+	wg.Wait()
+}
+
+func BenchmarkProperty_ASCII(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		property('a')
+	}
+}
+
+func BenchmarkProperty_ExtendedASCII(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		property('¿')
+	}
+}
+
+func BenchmarkProperty_Unicode(b *testing.B) {
+	var runes = [...]rune{
+		0x0981,  // Mn    BENGALI SIGN CANDRABINDU
+		0x2666,  // E0.6  [2]   (♥️..♦️)  heart suit..diamond suit
+		0x1F986, // E3.0  [13]  (🦅..🦑)  eagle..squid
+		0x1F602, // E0.6  [6]   (😁..😆)  beaming face with smiling eyes..grinning squinting face
+	}
+	for i := 0; i < b.N; i++ {
+		property(runes[i%len(runes)])
+	}
+}


### PR DESCRIPTION
This commit improves the layout of the "parser transition state" and
"grapheme code point" data structures; changes them to use structs
instead of arrays; and adds an ASCII and Extended-ASCII fast path for
the property() function.

Overall, this results in a ~5.5x speedup for Graphemes.Next().

```
goos: darwin
goarch: arm64
pkg: github.com/rivo/uniseg

name                        old time/op    new time/op    delta
GraphemesClass-10             2.87µs ± 0%    0.76µs ± 0%  -73.50%  (p=0.000 n=10+8)
GraphemesNext-10              2.55µs ± 0%    0.47µs ± 0%  -81.75%  (p=0.000 n=8+9)
GraphemesFunctionBytes-10     0.64ns ± 0%    0.64ns ± 0%     ~     (p=0.344 n=9+10)
GraphemesFunctionString-10    0.64ns ± 0%    0.64ns ± 0%     ~     (p=0.190 n=10+9)

name                        old alloc/op   new alloc/op   delta
GraphemesClass-10               944B ± 0%      944B ± 0%     ~     (all equal)
GraphemesNext-10               0.00B          0.00B          ~     (all equal)
GraphemesFunctionBytes-10      0.00B          0.00B          ~     (all equal)
GraphemesFunctionString-10     0.00B          0.00B          ~     (all equal)

name                        old allocs/op  new allocs/op  delta
GraphemesClass-10               3.00 ± 0%      3.00 ± 0%     ~     (all equal)
GraphemesNext-10                0.00           0.00          ~     (all equal)
GraphemesFunctionBytes-10       0.00           0.00          ~     (all equal)
GraphemesFunctionString-10      0.00           0.00          ~     (all equal)
```

*Note*: The GraphemesNext benchmark was backported to d6773baf for these
comparisons.