### PR TITLE
add NewGraphemesFromRunes

### DIFF
--- a/grapheme.go
+++ b/grapheme.go
@@ -138,6 +138,23 @@ func NewGraphemes(s string) *Graphemes {
 	return g
 }
 
+// NewGraphemesFromRunes returns a new grapheme cluster iterator from []runes rs.
+func NewGraphemesFromRunes(rs []rune) *Graphemes {
+	indices := make([]int, len(rs)+1)
+	pos := 0
+	for i, r := range rs {
+		indices[i] = pos
+		pos += utf8.RuneLen(r)
+	}
+	indices[len(indices)-1] = pos
+	g := &Graphemes{
+		codePoints: rs,
+		indices:    indices,
+	}
+	g.Next() // Parse ahead.
+	return g
+}
+
 // Next advances the iterator by one grapheme cluster and returns false if no
 // clusters are left. This function must be called before the first cluster is
 // accessed.

--- a/grapheme_test.go
+++ b/grapheme_test.go
@@ -1,6 +1,7 @@
 package uniseg
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -329,6 +330,16 @@ func TestGraphemesFunctionString(t *testing.T) {
 				testCase.original,
 				index,
 				len(testCase.expected))
+		}
+	}
+}
+
+func TestNewGraphemesFromRunes(t *testing.T) {
+	for _, test := range testCases {
+		want := NewGraphemes(test.original)
+		got := NewGraphemesFromRunes([]rune(test.original))
+		if !reflect.DeepEqual(want, got) {
+			t.Fatalf("NewFromRunes(%q)\ngot:  %#v\nwant: %#v", test.original, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Add NewGraphemesFromRunes which allows for creating a new Graphemes
struct from a slice of runes (saving the []rune => str => []rune
conversion).