### PR TITLE
fix position of `Code generated` comments.

### DIFF
--- a/eastasianwidth.go
+++ b/eastasianwidth.go
@@ -1,13 +1,13 @@
-package uniseg
-
 // Code generated via go generate from gen_properties.go. DO NOT EDIT.
+
+package uniseg
 
 // eastAsianWidth are taken from
 // https://www.unicode.org/Public/14.0.0/ucd/EastAsianWidth.txt
 // and
 // https://unicode.org/Public/14.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 10, 2022. See https://www.unicode.org/license.html for the Unicode
+// on July 17, 2023. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
 var eastAsianWidth = [][3]int{
 	{0x0000, 0x001F, prN},     // Cc    [32] <control-0000>..<control-001F>

--- a/emojipresentation.go
+++ b/emojipresentation.go
@@ -1,13 +1,13 @@
-package uniseg
-
 // Code generated via go generate from gen_properties.go. DO NOT EDIT.
+
+package uniseg
 
 // emojiPresentation are taken from
 //
 // and
 // https://unicode.org/Public/14.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 10, 2022. See https://www.unicode.org/license.html for the Unicode
+// on July 17, 2023. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
 var emojiPresentation = [][3]int{
 	{0x231A, 0x231B, prEmojiPresentation},   // E0.6   [2] (⌚..⌛)    watch..hourglass done

--- a/gen_breaktest.go
+++ b/gen_breaktest.go
@@ -76,9 +76,9 @@ func parse(url string) ([]byte, error) {
 
 	buf := new(bytes.Buffer)
 	buf.Grow(120 << 10)
-	buf.WriteString(`package uniseg
+	buf.WriteString(`// Code generated via go generate from gen_breaktest.go. DO NOT EDIT.
 
-// Code generated via go generate from gen_breaktest.go. DO NOT EDIT.
+package uniseg
 
 // ` + os.Args[3] + ` are Grapheme testcases taken from
 // ` + url + `
@@ -136,7 +136,9 @@ var (
 //
 // E.g. for the input b="÷ 0020 × 0308 ÷ 1F1E6 ÷"
 // it will append
-//     "\u0020\u0308\U0001F1E6"
+//
+//	"\u0020\u0308\U0001F1E6"
+//
 // and "[][]rune{{0x0020,0x0308},{0x1F1E6},}"
 // to orig and exp respectively.
 //

--- a/gen_properties.go
+++ b/gen_properties.go
@@ -200,9 +200,9 @@ func parse(propertyURL, emojiProperty string, includeGeneralCategory bool) (stri
 // ` + emojiURL + `
 // ("Extended_Pictographic" only)`
 	}
-	buf.WriteString(`package uniseg
+	buf.WriteString(`// Code generated via go generate from gen_properties.go. DO NOT EDIT.
 
-// Code generated via go generate from gen_properties.go. DO NOT EDIT.
+package uniseg
 
 // ` + os.Args[3] + ` are taken from
 // ` + propertyURL + emojiComment + `

--- a/graphemebreak_test.go
+++ b/graphemebreak_test.go
@@ -1,10 +1,10 @@
-package uniseg
-
 // Code generated via go generate from gen_breaktest.go. DO NOT EDIT.
+
+package uniseg
 
 // graphemeBreakTestCases are Grapheme testcases taken from
 // https://www.unicode.org/Public/14.0.0/ucd/auxiliary/GraphemeBreakTest.txt
-// on September 10, 2022. See
+// on July 17, 2023. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
 var graphemeBreakTestCases = []testCase{
 	{original: "\u0020\u0020", expected: [][]rune{{0x0020}, {0x0020}}},                                                                                 // ÷ [0.2] SPACE (Other) ÷ [999.0] SPACE (Other) ÷ [0.3]

--- a/graphemeproperties.go
+++ b/graphemeproperties.go
@@ -1,13 +1,13 @@
-package uniseg
-
 // Code generated via go generate from gen_properties.go. DO NOT EDIT.
+
+package uniseg
 
 // graphemeCodePoints are taken from
 // https://www.unicode.org/Public/14.0.0/ucd/auxiliary/GraphemeBreakProperty.txt
 // and
 // https://unicode.org/Public/14.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 10, 2022. See https://www.unicode.org/license.html for the Unicode
+// on July 17, 2023. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
 var graphemeCodePoints = [][3]int{
 	{0x0000, 0x0009, prControl},                // Cc  [10] <control-0000>..<control-0009>

--- a/linebreak_test.go
+++ b/linebreak_test.go
@@ -1,10 +1,10 @@
-package uniseg
-
 // Code generated via go generate from gen_breaktest.go. DO NOT EDIT.
+
+package uniseg
 
 // lineBreakTestCases are Grapheme testcases taken from
 // https://www.unicode.org/Public/14.0.0/ucd/auxiliary/LineBreakTest.txt
-// on September 10, 2022. See
+// on July 17, 2023. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
 var lineBreakTestCases = []testCase{
 	{original: "\u0023\u0023", expected: [][]rune{{0x0023, 0x0023}}},                                                                                                                               // × [0.3] NUMBER SIGN (AL) × [28.0] NUMBER SIGN (AL) ÷ [0.3]

--- a/lineproperties.go
+++ b/lineproperties.go
@@ -1,13 +1,13 @@
-package uniseg
-
 // Code generated via go generate from gen_properties.go. DO NOT EDIT.
+
+package uniseg
 
 // lineBreakCodePoints are taken from
 // https://www.unicode.org/Public/14.0.0/ucd/LineBreak.txt
 // and
 // https://unicode.org/Public/14.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 10, 2022. See https://www.unicode.org/license.html for the Unicode
+// on July 17, 2023. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
 var lineBreakCodePoints = [][4]int{
 	{0x0000, 0x0008, prCM, gcCc},     //     [9] <control-0000>..<control-0008>

--- a/sentencebreak_test.go
+++ b/sentencebreak_test.go
@@ -1,10 +1,10 @@
-package uniseg
-
 // Code generated via go generate from gen_breaktest.go. DO NOT EDIT.
+
+package uniseg
 
 // sentenceBreakTestCases are Grapheme testcases taken from
 // https://www.unicode.org/Public/14.0.0/ucd/auxiliary/SentenceBreakTest.txt
-// on September 10, 2022. See
+// on July 17, 2023. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
 var sentenceBreakTestCases = []testCase{
 	{original: "\u0001\u0001", expected: [][]rune{{0x0001, 0x0001}}},                                               // ÷ [0.2] <START OF HEADING> (Other) × [998.0] <START OF HEADING> (Other) ÷ [0.3]

--- a/sentenceproperties.go
+++ b/sentenceproperties.go
@@ -1,13 +1,13 @@
-package uniseg
-
 // Code generated via go generate from gen_properties.go. DO NOT EDIT.
+
+package uniseg
 
 // sentenceBreakCodePoints are taken from
 // https://www.unicode.org/Public/14.0.0/ucd/auxiliary/SentenceBreakProperty.txt
 // and
 // https://unicode.org/Public/14.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 10, 2022. See https://www.unicode.org/license.html for the Unicode
+// on July 17, 2023. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
 var sentenceBreakCodePoints = [][3]int{
 	{0x0009, 0x0009, prSp},        // Cc       <control-0009>

--- a/wordbreak_test.go
+++ b/wordbreak_test.go
@@ -1,10 +1,10 @@
-package uniseg
-
 // Code generated via go generate from gen_breaktest.go. DO NOT EDIT.
+
+package uniseg
 
 // wordBreakTestCases are Grapheme testcases taken from
 // https://www.unicode.org/Public/14.0.0/ucd/auxiliary/WordBreakTest.txt
-// on September 10, 2022. See
+// on July 17, 2023. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
 var wordBreakTestCases = []testCase{
 	{original: "\u0001\u0001", expected: [][]rune{{0x0001}, {0x0001}}},                                                                                 // ÷ [0.2] <START OF HEADING> (Other) ÷ [999.0] <START OF HEADING> (Other) ÷ [0.3]

--- a/wordproperties.go
+++ b/wordproperties.go
@@ -1,13 +1,13 @@
-package uniseg
-
 // Code generated via go generate from gen_properties.go. DO NOT EDIT.
+
+package uniseg
 
 // workBreakCodePoints are taken from
 // https://www.unicode.org/Public/14.0.0/ucd/auxiliary/WordBreakProperty.txt
 // and
 // https://unicode.org/Public/14.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 10, 2022. See https://www.unicode.org/license.html for the Unicode
+// on July 17, 2023. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
 var workBreakCodePoints = [][3]int{
 	{0x000A, 0x000A, prLF},                     // Cc       <control-000A>


### PR DESCRIPTION
Go extension of VSCode warns when I modify the generated codes:

<img width="591" alt="This file seems to be generated. DO NOT EDIT." src="https://github.com/rivo/uniseg/assets/1157344/9a53b5ad-e272-4272-b6c4-4a396b1eb163">

However, this feature doesn't work with this project.
For example, I've modified [emojipresentation.go](https://github.com/rivo/uniseg/blob/c29cfd277c87e6115f89ba29f0f7b0544b2bfd68/emojipresentation.go) that is generated by [gen_properties.go](https://github.com/rivo/uniseg/blob/c29cfd277c87e6115f89ba29f0f7b0544b2bfd68/gen_properties.go), but I never see any warning message.
It seems that the Go extension doesn't understand `emojipresentation.go` is generated code.

According to the document of `go generate`, `// Code generated` comments must appear earlier.

https://pkg.go.dev/cmd/go#hdr-Generate_Go_files_by_processing_source

> To convey to humans and machine tools that code is generated, generated source should have a line that matches the following regular expression (in Go syntax):
>
>     ^// Code generated .* DO NOT EDIT\.$
>
> **This line must appear before the first non-comment, non-blank text in the file.**
