### PR TITLE
avoid overflow when computing middle

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -139,7 +139,7 @@ func propertySearch[E interface{ [3]int | [4]int }](dictionary []E, r rune) (res
 	from := 0
 	to := len(dictionary)
 	for to > from {
-		middle := (from + to) / 2
+		middle := int(uint(from+to) >> 1) // avoid overflow when computing middle
 		cpRange := dictionary[middle]
 		if int(r) < cpRange[0] {
 			to = middle


### PR DESCRIPTION
`from+to` may be greater than `math.MaxInt`,
so we need to take care of overflow.
casting int to uint is reasonable way.

Actually, Go's standard library uses this trick:

https://github.com/golang/go/blob/2eca0b1e1663d826893b6b1fd8bd89da98e65d1e/src/sort/search.go#L63