### PR TITLE
check the size of properties.

### DIFF
--- a/gen_properties.go
+++ b/gen_properties.go
@@ -178,9 +178,8 @@ func parse(propertyURL, emojiProperty string, includeGeneralCategory bool) (stri
 		}
 	}
 
-	// check the size of properties.
+	// Avoid overflow during binary search.
 	if len(properties) >= 1<<31 {
-		// propertySearch cause overflow in this case.
 		// see https://github.com/rivo/uniseg/pull/37
 		return "", errors.New("too many properties")
 	}

--- a/gen_properties.go
+++ b/gen_properties.go
@@ -180,7 +180,6 @@ func parse(propertyURL, emojiProperty string, includeGeneralCategory bool) (stri
 
 	// Avoid overflow during binary search.
 	if len(properties) >= 1<<31 {
-		// see https://github.com/rivo/uniseg/pull/37
 		return "", errors.New("too many properties")
 	}
 

--- a/gen_properties.go
+++ b/gen_properties.go
@@ -178,6 +178,13 @@ func parse(propertyURL, emojiProperty string, includeGeneralCategory bool) (stri
 		}
 	}
 
+	// check the size of properties.
+	if len(properties) >= 1<<31 {
+		// propertySearch cause overflow in this case.
+		// see https://github.com/rivo/uniseg/pull/37
+		return "", errors.New("too many properties")
+	}
+
 	// Sort properties.
 	sort.Slice(properties, func(i, j int) bool {
 		left, _ := strconv.ParseUint(properties[i][0], 16, 64)


### PR DESCRIPTION
[propertySearch](https://github.com/rivo/uniseg/blob/ac807292cb7cacfe6d6227ea7c5793c4acd31b88/properties.go#L134-L155) may overflow if `len(properties) >= 1<<31`.
See also: https://github.com/rivo/uniseg/pull/37