### PR TITLE
prKatakana should be wbKatakana.

### DIFF
--- a/wordrules.go
+++ b/wordrules.go
@@ -97,7 +97,7 @@ var wbTransitions = map[[2]int][3]int{
 	{wbExtendNumLet, prALetter}:      {wbALetter, wbDontBreak, 132},
 	{wbExtendNumLet, prHebrewLetter}: {wbHebrewLetter, wbDontBreak, 132},
 	{wbExtendNumLet, prNumeric}:      {wbNumeric, wbDontBreak, 132},
-	{wbExtendNumLet, prKatakana}:     {prKatakana, wbDontBreak, 132},
+	{wbExtendNumLet, prKatakana}:     {wbKatakana, wbDontBreak, 132},
 }
 
 // transitionWordBreakState determines the new state of the word break parser


### PR DESCRIPTION
wbTransitions must be:

    {wbXX, prXX}: {wbXX, wbDontBreak, 132},
    // or
    {wbXX, prXX}: {wbXX, wbBreak, 132},