### PR TITLE
fix benchmarks

### DIFF
--- a/grapheme_test.go
+++ b/grapheme_test.go
@@ -6,6 +6,8 @@ import (
 
 const benchmarkStr = "This is 🏳️‍🌈, a test string ツ for grapheme cluster testing. 🏋🏽‍♀️🙂🙂 It's only relevant for benchmark tests."
 
+var benchmarkBytes = []byte(benchmarkStr)
+
 // Variables to avoid compiler optimizations.
 var resultRunes []rune
 
@@ -501,10 +503,10 @@ func BenchmarkGraphemesClass(b *testing.B) {
 
 // Benchmark the use of the Graphemes function for byte slices.
 func BenchmarkGraphemesFunctionBytes(b *testing.B) {
-	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
 		state := -1
+		str := benchmarkBytes
 		for len(str) > 0 {
 			c, str, _, state = FirstGraphemeCluster(str, state)
 			resultRunes = []rune(string(c))
@@ -514,10 +516,10 @@ func BenchmarkGraphemesFunctionBytes(b *testing.B) {
 
 // Benchmark the use of the Graphemes function for strings.
 func BenchmarkGraphemesFunctionString(b *testing.B) {
-	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
 		state := -1
+		str := benchmarkStr
 		for len(str) > 0 {
 			c, str, _, state = FirstGraphemeClusterInString(str, state)
 			resultRunes = []rune(c)

--- a/line_test.go
+++ b/line_test.go
@@ -157,10 +157,10 @@ func TestHasTrailingLineBreakInString(t *testing.T) {
 
 // Benchmark the use of the line break function for byte slices.
 func BenchmarkLineFunctionBytes(b *testing.B) {
-	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
 		state := -1
+		str := benchmarkBytes
 		for len(str) > 0 {
 			c, str, _, state = FirstLineSegment(str, state)
 			resultRunes = []rune(string(c))
@@ -170,10 +170,10 @@ func BenchmarkLineFunctionBytes(b *testing.B) {
 
 // Benchmark the use of the line break function for strings.
 func BenchmarkLineFunctionString(b *testing.B) {
-	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
 		state := -1
+		str := benchmarkStr
 		for len(str) > 0 {
 			c, str, _, state = FirstLineSegmentInString(str, state)
 			resultRunes = []rune(c)

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -128,10 +128,10 @@ func TestSentenceCasesString(t *testing.T) {
 
 // Benchmark the use of the sentence break function for byte slices.
 func BenchmarkSentenceFunctionBytes(b *testing.B) {
-	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
 		state := -1
+		str := benchmarkBytes
 		for len(str) > 0 {
 			c, str, state = FirstSentence(str, state)
 			resultRunes = []rune(string(c))
@@ -141,10 +141,10 @@ func BenchmarkSentenceFunctionBytes(b *testing.B) {
 
 // Benchmark the use of the sentence break function for strings.
 func BenchmarkSentenceFunctionString(b *testing.B) {
-	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
 		state := -1
+		str := benchmarkStr
 		for len(str) > 0 {
 			c, str, state = FirstSentenceInString(str, state)
 			resultRunes = []rune(c)

--- a/step_test.go
+++ b/step_test.go
@@ -434,10 +434,10 @@ func TestStepStringSentence(t *testing.T) {
 
 // Benchmark the use of the [Step] function.
 func BenchmarkStepBytes(b *testing.B) {
-	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
 		state := -1
+		str := benchmarkBytes
 		for len(str) > 0 {
 			c, str, _, state = Step(str, state)
 			resultRunes = []rune(string(c))
@@ -447,10 +447,10 @@ func BenchmarkStepBytes(b *testing.B) {
 
 // Benchmark the use of the StepString() function.
 func BenchmarkStepString(b *testing.B) {
-	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
 		state := -1
+		str := benchmarkStr
 		for len(str) > 0 {
 			c, str, _, state = StepString(str, state)
 			resultRunes = []rune(c)

--- a/word_test.go
+++ b/word_test.go
@@ -126,10 +126,10 @@ func TestWordCasesString(t *testing.T) {
 
 // Benchmark the use of the word break function for byte slices.
 func BenchmarkWordFunctionBytes(b *testing.B) {
-	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
 		state := -1
+		str := benchmarkBytes
 		for len(str) > 0 {
 			c, str, state = FirstWord(str, state)
 			resultRunes = []rune(string(c))
@@ -139,10 +139,10 @@ func BenchmarkWordFunctionBytes(b *testing.B) {
 
 // Benchmark the use of the word break function for strings.
 func BenchmarkWordFunctionString(b *testing.B) {
-	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
 		state := -1
+		str := benchmarkStr
 		for len(str) > 0 {
 			c, str, state = FirstWordInString(str, state)
 			resultRunes = []rune(c)


### PR DESCRIPTION
The results of benchmarks are a bit odd.

```
$ go test -bench .
goos: darwin
goarch: amd64
pkg: github.com/rivo/uniseg
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkGraphemesClass-8            	   39541	     29322 ns/op
BenchmarkGraphemesFunctionBytes-8    	1000000000	         0.4588 ns/op
BenchmarkGraphemesFunctionString-8   	1000000000	         0.4627 ns/op
BenchmarkLineFunctionBytes-8         	1000000000	         0.4649 ns/op
BenchmarkLineFunctionString-8        	1000000000	         0.4647 ns/op
BenchmarkSentenceFunctionBytes-8     	1000000000	         0.4732 ns/op
BenchmarkSentenceFunctionString-8    	1000000000	         0.4660 ns/op
BenchmarkStepBytes-8                 	1000000000	         0.4706 ns/op
BenchmarkStepString-8                	1000000000	         0.4561 ns/op
BenchmarkWordFunctionBytes-8         	1000000000	         0.4741 ns/op
BenchmarkWordFunctionString-8        	1000000000	         0.4545 ns/op
PASS
ok  	github.com/rivo/uniseg	7.388s
```

Even a simple function call takes 0.8500 ns/op in my environment. It is too fast to finish in less than 0.5 ns/op, even though it should be doing more processing.

```go
func Benchmark(b *testing.B) {
	for i := 0; i < b.N; i++ {
		f()
	}
}

//go:noinline
func f() {}
```

This pull request fixes these benchmarks.

```
$ go test -bench .
goos: darwin
goarch: amd64
pkg: github.com/rivo/uniseg
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
Benchmark-8   	1000000000	         0.8500 ns/op
PASS
ok  	github.com/rivo/uniseg	1.117s
```

```
goos: darwin
goarch: amd64
pkg: github.com/rivo/uniseg
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkGraphemesClass-8            	   39367	     30177 ns/op
BenchmarkGraphemesFunctionBytes-8    	  107184	     10970 ns/op
BenchmarkGraphemesFunctionString-8   	  108490	     10801 ns/op
BenchmarkLineFunctionBytes-8         	  144932	      9098 ns/op
BenchmarkLineFunctionString-8        	  144598	      8424 ns/op
BenchmarkSentenceFunctionBytes-8     	  139418	      7312 ns/op
BenchmarkSentenceFunctionString-8    	  169611	      6860 ns/op
BenchmarkStepBytes-8                 	   39217	     31004 ns/op
BenchmarkStepString-8                	   39751	     30076 ns/op
BenchmarkWordFunctionBytes-8         	  172719	      6533 ns/op
BenchmarkWordFunctionString-8        	  188823	      6205 ns/op
PASS
ok  	github.com/rivo/uniseg	15.263s
```