### PR TITLE
Bazelify the project.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "uniseg",
+    srcs = [
+        "doc.go",
+        "eastasianwidth.go",
+        "emojipresentation.go",
+        "gen_properties.go",
+        "grapheme.go",
+        "graphemeproperties.go",
+        "graphemerules.go",
+        "line.go",
+        "lineproperties.go",
+        "linerules.go",
+        "properties.go",
+        "sentence.go",
+        "sentenceproperties.go",
+        "sentencerules.go",
+        "step.go",
+        "width.go",
+        "word.go",
+        "wordproperties.go",
+        "wordrules.go",
+    ],
+    importpath = "github.com/rivo/uniseg",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":uniseg",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "uniseg_test",
+    srcs = [
+        "examples_test.go",
+        "gen_breaktest.go",
+        "graphemebreak_test.go",
+        "grapheme_test.go",
+        "linebreak_test.go",
+        "line_test.go",
+        "sentencebreak_test.go",
+        "sentence_test.go",
+        "step_test.go",
+        "width_test.go",
+        "wordbreak_test.go",
+        "word_test.go",
+    ],
+    embed = [":uniseg"],
+    timeout = "short",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,30 @@
+workspace(name = "com_github_rivo_uniseg")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "727f3e4edd96ea20c29e8c2ca9e8d2af724d8c7778e7923a854b2c80952bc405",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.20.5")
+
+gazelle_dependencies()


### PR DESCRIPTION
Add bazel files so that uniseg can be used in projects managed with bazel.

```
$ bazel build //...
INFO: Analyzed 3 targets (1 packages loaded, 34 targets configured).
INFO: Found 3 targets...
INFO: Elapsed time: 0.146s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

$ bazel test -t- //...
INFO: Analyzed 3 targets (0 packages loaded, 2 targets configured).
INFO: Found 2 targets and 1 test target...
INFO: Elapsed time: 0.159s, Critical Path: 0.04s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//:uniseg_test                                                           PASSED in 0.0s

Executed 1 out of 1 test: 1 test passes.
```