### PR TITLE
Allow configuring the width of East Asian ambiguous width characters

### DIFF
--- a/width.go
+++ b/width.go
@@ -1,5 +1,8 @@
 package uniseg
 
+// EastAsianAmbiguousWidth specifies the monospace width for East Asian
+// characters classified as Ambiguous. The default is 1 but some rare fonts
+// render them with a width of 2.
 var EastAsianAmbiguousWidth = 1
 
 // runeWidth returns the monospace width for the given rune. The provided

--- a/width.go
+++ b/width.go
@@ -1,5 +1,7 @@
 package uniseg
 
+var EastAsianAmbiguousWidth = 1
+
 // runeWidth returns the monospace width for the given rune. The provided
 // grapheme property is a value mapped by the [graphemeCodePoints] table.
 //
@@ -36,6 +38,8 @@ func runeWidth(r rune, graphemeProperty int) int {
 	switch property(eastAsianWidth, r) {
 	case prW, prF:
 		return 2
+	case prA:
+		return EastAsianAmbiguousWidth
 	}
 
 	return 1


### PR DESCRIPTION
Would you be willing to accept a patch that allows changing the expected width of East Asian ambiguous width characters?

Similarly to [`RUNEWIDTH_EASTASIAN=1` of go-runewidth](https://github.com/mattn/go-runewidth/blob/44b7c5b4d67df8ca22917b6800c158a6d3be3560/runewidth.go#L31) or [`set ambiwidth=double` of Vim](https://vimdoc.sourceforge.net/htmldoc/options.html#'ambiwidth').