### PR TITLE
Add 2 reference articles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 This Go package implements Unicode Text Segmentation according to [Unicode Standard Annex #29](https://unicode.org/reports/tr29/), Unicode Line Breaking according to [Unicode Standard Annex #14](https://unicode.org/reports/tr14/) (Unicode version 15.0.0), and monospace font string width calculation similar to [wcwidth](https://man7.org/linux/man-pages/man3/wcwidth.3.html).
 
+It allows to pass all the tests mentionned in [The String Type is Broken](https://mortoray.com/the-string-type-is-broken/) and [this article](https://bignerdranch.com/blog/elixir-and-unicode-part-1-unicode-and-utf-8-explained/).
+
 ## Background
 
 ### Grapheme Clusters


### PR DESCRIPTION
Hi, nice library!  
In this PR I'm suggesting to reference 2 articles in the README, allowing a better comprehension of use cases and the necessity to have good unicode support, with practical examples.    
The second article re-use the tests of the first one, it's just a bit easier to read (clear table with tests and results).

* https://mortoray.com/the-string-type-is-broken/
* https://bignerdranch.com/blog/elixir-and-unicode-part-1-unicode-and-utf-8-explained/

I hope you find it useful!