### PR TITLE
use rune type instead of int for unicode tables

### DIFF
--- a/eastasianwidth.go
+++ b/eastasianwidth.go
@@ -7,9 +7,9 @@ package uniseg
 // and
 // https://unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 5, 2023. See https://www.unicode.org/license.html for the Unicode
+// on July 2, 2025. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
-var eastAsianWidth = [][3]int{
+var eastAsianWidth = [][3]rune{
 	{0x0000, 0x001F, prN},     // Cc    [32] <control-0000>..<control-001F>
 	{0x0020, 0x0020, prNa},    // Zs         SPACE
 	{0x0021, 0x0023, prNa},    // Po     [3] EXCLAMATION MARK..NUMBER SIGN

--- a/emojipresentation.go
+++ b/emojipresentation.go
@@ -7,9 +7,9 @@ package uniseg
 // and
 // https://unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 5, 2023. See https://www.unicode.org/license.html for the Unicode
+// on July 2, 2025. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
-var emojiPresentation = [][3]int{
+var emojiPresentation = [][3]rune{
 	{0x231A, 0x231B, prEmojiPresentation},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
 	{0x23E9, 0x23EC, prEmojiPresentation},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
 	{0x23F0, 0x23F0, prEmojiPresentation},   // E0.6   [1] (⏰)       alarm clock

--- a/gen_properties.go
+++ b/gen_properties.go
@@ -213,7 +213,7 @@ package uniseg
 // ` + propertyURL + emojiComment + `
 // on ` + time.Now().Format("January 2, 2006") + `. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
-var ` + os.Args[3] + ` = [][` + strconv.Itoa(columns) + `]int{
+var ` + os.Args[3] + ` = [][` + strconv.Itoa(columns) + `]rune{
 	`)
 
 	// Properties.

--- a/graphemebreak_test.go
+++ b/graphemebreak_test.go
@@ -4,7 +4,7 @@ package uniseg
 
 // graphemeBreakTestCases are Grapheme testcases taken from
 // https://www.unicode.org/Public/15.0.0/ucd/auxiliary/GraphemeBreakTest.txt
-// on September 5, 2023. See
+// on July 2, 2025. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
 var graphemeBreakTestCases = []testCase{
 	{original: "\u0020\u0020", expected: [][]rune{{0x0020}, {0x0020}}},                                                                                 // ÷ [0.2] SPACE (Other) ÷ [999.0] SPACE (Other) ÷ [0.3]

--- a/graphemeproperties.go
+++ b/graphemeproperties.go
@@ -7,9 +7,9 @@ package uniseg
 // and
 // https://unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 5, 2023. See https://www.unicode.org/license.html for the Unicode
+// on July 2, 2025. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
-var graphemeCodePoints = [][3]int{
+var graphemeCodePoints = [][3]rune{
 	{0x0000, 0x0009, prControl},                // Cc  [10] <control-0000>..<control-0009>
 	{0x000A, 0x000A, prLF},                     // Cc       <control-000A>
 	{0x000B, 0x000C, prControl},                // Cc   [2] <control-000B>..<control-000C>

--- a/linebreak_test.go
+++ b/linebreak_test.go
@@ -4,7 +4,7 @@ package uniseg
 
 // lineBreakTestCases are Grapheme testcases taken from
 // https://www.unicode.org/Public/15.0.0/ucd/auxiliary/LineBreakTest.txt
-// on September 5, 2023. See
+// on July 2, 2025. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
 var lineBreakTestCases = []testCase{
 	{original: "\u0023\u0023", expected: [][]rune{{0x0023, 0x0023}}},                                                                                                                               // × [0.3] NUMBER SIGN (AL) × [28.0] NUMBER SIGN (AL) ÷ [0.3]

--- a/lineproperties.go
+++ b/lineproperties.go
@@ -7,9 +7,9 @@ package uniseg
 // and
 // https://unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 5, 2023. See https://www.unicode.org/license.html for the Unicode
+// on July 2, 2025. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
-var lineBreakCodePoints = [][4]int{
+var lineBreakCodePoints = [][4]rune{
 	{0x0000, 0x0008, prCM, gcCc},     //     [9] <control-0000>..<control-0008>
 	{0x0009, 0x0009, prBA, gcCc},     //         <control-0009>
 	{0x000A, 0x000A, prLF, gcCc},     //         <control-000A>

--- a/properties.go
+++ b/properties.go
@@ -134,18 +134,18 @@ const (
 // propertySearch performs a binary search on a property slice and returns the
 // entry whose range (start = first array element, end = second array element)
 // includes r, or an array of 0's if no such entry was found.
-func propertySearch[E interface{ [3]int | [4]int }](dictionary []E, r rune) (result E) {
+func propertySearch[E interface{ [3]rune | [4]rune }](dictionary []E, r rune) (result E) {
 	// Run a binary search.
 	from := 0
 	to := len(dictionary)
 	for to > from {
 		middle := (from + to) / 2
 		cpRange := dictionary[middle]
-		if int(r) < cpRange[0] {
+		if r < cpRange[0] {
 			to = middle
 			continue
 		}
-		if int(r) > cpRange[1] {
+		if r > cpRange[1] {
 			from = middle + 1
 			continue
 		}
@@ -156,8 +156,8 @@ func propertySearch[E interface{ [3]int | [4]int }](dictionary []E, r rune) (res
 
 // property returns the Unicode property value (see constants above) of the
 // given code point.
-func property(dictionary [][3]int, r rune) int {
-	return propertySearch(dictionary, r)[2]
+func property(dictionary [][3]rune, r rune) int {
+	return int(propertySearch(dictionary, r)[2])
 }
 
 // propertyLineBreak returns the Unicode property value and General Category
@@ -174,7 +174,7 @@ func propertyLineBreak(r rune) (property, generalCategory int) {
 		return prNU, gcNd
 	}
 	entry := propertySearch(lineBreakCodePoints, r)
-	return entry[2], entry[3]
+	return int(entry[2]), int(entry[3])
 }
 
 // propertyGraphemes returns the Unicode grapheme cluster property value of the

--- a/sentencebreak_test.go
+++ b/sentencebreak_test.go
@@ -4,7 +4,7 @@ package uniseg
 
 // sentenceBreakTestCases are Grapheme testcases taken from
 // https://www.unicode.org/Public/15.0.0/ucd/auxiliary/SentenceBreakTest.txt
-// on September 5, 2023. See
+// on July 2, 2025. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
 var sentenceBreakTestCases = []testCase{
 	{original: "\u0001\u0001", expected: [][]rune{{0x0001, 0x0001}}},                                               // ÷ [0.2] <START OF HEADING> (Other) × [998.0] <START OF HEADING> (Other) ÷ [0.3]

--- a/sentenceproperties.go
+++ b/sentenceproperties.go
@@ -7,9 +7,9 @@ package uniseg
 // and
 // https://unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 5, 2023. See https://www.unicode.org/license.html for the Unicode
+// on July 2, 2025. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
-var sentenceBreakCodePoints = [][3]int{
+var sentenceBreakCodePoints = [][3]rune{
 	{0x0009, 0x0009, prSp},        // Cc       <control-0009>
 	{0x000A, 0x000A, prLF},        // Cc       <control-000A>
 	{0x000B, 0x000C, prSp},        // Cc   [2] <control-000B>..<control-000C>

--- a/wordbreak_test.go
+++ b/wordbreak_test.go
@@ -4,7 +4,7 @@ package uniseg
 
 // wordBreakTestCases are Grapheme testcases taken from
 // https://www.unicode.org/Public/15.0.0/ucd/auxiliary/WordBreakTest.txt
-// on September 5, 2023. See
+// on July 2, 2025. See
 // https://www.unicode.org/license.html for the Unicode license agreement.
 var wordBreakTestCases = []testCase{
 	{original: "\u0001\u0001", expected: [][]rune{{0x0001}, {0x0001}}},                                                                                 // ÷ [0.2] <START OF HEADING> (Other) ÷ [999.0] <START OF HEADING> (Other) ÷ [0.3]

--- a/wordproperties.go
+++ b/wordproperties.go
@@ -7,9 +7,9 @@ package uniseg
 // and
 // https://unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt
 // ("Extended_Pictographic" only)
-// on September 5, 2023. See https://www.unicode.org/license.html for the Unicode
+// on July 2, 2025. See https://www.unicode.org/license.html for the Unicode
 // license agreement.
-var workBreakCodePoints = [][3]int{
+var workBreakCodePoints = [][3]rune{
 	{0x000A, 0x000A, prLF},                     // Cc       <control-000A>
 	{0x000B, 0x000C, prNewline},                // Cc   [2] <control-000B>..<control-000C>
 	{0x000D, 0x000D, prCR},                     // Cc       <control-000D>


### PR DESCRIPTION
int is 64 bit on 64 bit platforms but each unicode char is only 32bit and go APIs generally use rune as type for it so switch to that.

The main motivation is to reduce the binary size with a small example program I see a about 170k reduce binary size footprint.

Note I went with minimal changes in terms of changing the API of various internal functions and cast back to int quite early. In theory one could make much more changes to use rune over int.